### PR TITLE
chore: macos and note related to unidentified developer

### DIFF
--- a/quick-start-aks.md
+++ b/quick-start-aks.md
@@ -130,7 +130,7 @@ kubectl apply -f https://github.com/nearform/initium-platform/releases/latest/do
 ## Setup Initium CLI.
 Ignore these steps in case you already have Initium CLI installed.
 
-- Download the lastest release of the CLI for your operating system [here](https://github.com/nearform/initium-cli/releases) and add it to your PATH.
+- Download the latest release of the CLI for your operating system [here](https://github.com/nearform/initium-cli/releases) and add it to your PATH (depending on your security settings on macOS, you may need to accept running an application from [unidentified developer](https://support.apple.com/en-us/HT202491)).
 - Alternatively you can build the CLI from source refer [repo](https://github.com/nearform/initium-cli)
 
 ## Deploy demo app via github actions on PR

--- a/quick-start-eks.md
+++ b/quick-start-eks.md
@@ -58,7 +58,7 @@ make argocd
 
 ## The CLI
 
-1. Download the lastest release of the CLI for your operating system [here](https://github.com/nearform/initium-cli/releases) and add it to your PATH.
+1. Download the latest release of the CLI for your operating system [here](https://github.com/nearform/initium-cli/releases) and add it to your PATH (depending on your security settings on macOS, you may need to accept running an application from [unidentified developer](https://support.apple.com/en-us/HT202491)).
 
 2. Fork the Initium [NodeJS demo app](https://github.com/nearform/initium-nodejs-demo-app)
     1. Remember to set the GitHub Actions workflow permissions to "read and write" [here](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#configuring-the-default-github_token-permissions)

--- a/quick-start-gke.md
+++ b/quick-start-gke.md
@@ -71,7 +71,7 @@ make argocd
 
 ## The CLI
 
-1. Download the lastest release of the CLI for your operating system [here](https://github.com/nearform/initium-cli/releases) and add it to your PATH.
+1. Download the latest release of the CLI for your operating system [here](https://github.com/nearform/initium-cli/releases) and add it to your PATH (depending on your security settings on macOS, you may need to accept running an application from [unidentified developer](https://support.apple.com/en-us/HT202491)).
 
 2. Fork the Initium [NodeJS demo app](https://github.com/nearform/initium-nodejs-demo-app)
     1. Remember to set the GitHub Actions workflow permissions to "read and write" [here](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#configuring-the-default-github_token-permissions)

--- a/quick-start.md
+++ b/quick-start.md
@@ -44,7 +44,7 @@ You can use [ngrok](https://ngrok.com/) to expose the platform to the GitHub act
 
 ## The CLI
 
-1. Download the lastest release of the CLI for your operating system [here](https://github.com/nearform/initium-cli/releases) and add it to your PATH.
+1. Download the latest release of the CLI for your operating system [here](https://github.com/nearform/initium-cli/releases) and add it to your PATH (depending on your security settings on macOS, you may need to accept running an application from [unidentified developer](https://support.apple.com/en-us/HT202491)).
 
 2. Fork and Clone the Initium [NodeJS demo app](https://github.com/nearform/initium-nodejs-demo-app)
 


### PR DESCRIPTION
On macOS, depending on the security settings, there might be a need to manually approve `initium` binary before running becomes it comes from unidentified developer. It would be nice to have a small note about that in the quick start guides.