### PR TITLE
chore: updated cloud quick starts for argocd installation

### DIFF
--- a/quick-start-aks.md
+++ b/quick-start-aks.md
@@ -102,10 +102,15 @@ kubectl cluster-info
 ```
 
 ### Install ArgoCD
-From the root of the `initium-platform` repo run below command
+Install ArgoCD with the values required by the platform:
 
 ```bash
-make argocd
+helm upgrade --install argocd argo-cd \
+  --repo https://argoproj.github.io/argo-helm \
+  --values https://github.com/nearform/initium-platform/releases/latest/download/argocd-helm-values.yaml \
+  --version 5.16.14 \
+  --namespace argocd \
+  --create-namespace
 ```
 
 ### Install ArgoCD Apps

--- a/quick-start-eks.md
+++ b/quick-start-eks.md
@@ -33,10 +33,15 @@ make asdf_install
 AWS_DEFAULT_REGION=<your default region> ~/.asdf/installs/eksctl/<eksctl version installed>/bin/eksctl create cluster
 ```
 
-4. Install ArgoCD (can be skipped if you already have a cluster and ArgoCD installed in it)
+4. Install ArgoCD with the values required by the platform:
 
 ```bash
-make argocd
+helm upgrade --install argocd argo-cd \
+  --repo https://argoproj.github.io/argo-helm \
+  --values https://github.com/nearform/initium-platform/releases/latest/download/argocd-helm-values.yaml \
+  --version 5.16.14 \
+  --namespace argocd \
+  --create-namespace
 ```
 
 5. Apply the `initium-platform` app-of-apps.yaml manifest

--- a/quick-start-gke.md
+++ b/quick-start-gke.md
@@ -46,10 +46,15 @@ gcloud container clusters create initium-cluster \
 
 **Step 5 is not needed if you already have ArgoCD installed in your cluster.**
 
-5. Install ArgoCD
+5. Install ArgoCD with the values required by the platform:
 
 ```bash
-make argocd
+helm upgrade --install argocd argo-cd \
+  --repo https://argoproj.github.io/argo-helm \
+  --values https://github.com/nearform/initium-platform/releases/latest/download/argocd-helm-values.yaml \
+  --version 5.16.14 \
+  --namespace argocd \
+  --create-namespace
 ```
 
 6. Apply the `initium-platform` app-of-apps.yaml manifest


### PR DESCRIPTION
The following updates the quick starts for clouds to make ArgoCD installation easier.

Has to be merged when https://github.com/nearform/initium-platform/pull/208 is merged and released.

Closes https://github.com/nearform/initium/issues/15.